### PR TITLE
Version 6.0.2 Release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ allprojects {
     group = rootProject.maven_group
 
     repositories {
+        mavenCentral()
         maven {
             url "https://maven.neoforged.net/releases/"
         }

--- a/changes.md
+++ b/changes.md
@@ -1,0 +1,41 @@
+# EyeMine Changelog
+
+## Version 6.0.2
+
+### Bug Fixes
+
+#### Gaze-Based Walking Refinements
+
+- **Walking now fully stops when gaze is at the on-screen keyboard or outside the window**: In 6.0.1, walking was reduced to 15% speed in these cases. After further testing, full stop is the correct behavior — the original "don't stop completely" feedback from Kirsty was about in-game camera pitch (looking up/down hills), not the on-screen keyboard area.
+
+- **Extreme pitch angles no longer fully stop walking**: Looking straight up or down (beyond 80°) now slows movement to 5% instead of stopping entirely. This preserves the ability to navigate hills and look around without losing all momentum.
+
+#### Dwell Action Improvements
+
+- **Dwell actions now suppressed when gaze is at keyboard area or outside window**: Prevents unintended dwell-triggered interactions (e.g., block placement, item use) while the user is interacting with the on-screen keyboard.
+
+---
+
+## Version 6.0.1
+
+### Bug Fixes
+
+#### Gaze Detection Improvements
+
+- **Fixed auto-walking not stopping when looking at keyboard area**: The GLFW cursor reset events at position (0,0) were incorrectly clearing the gaze-below-threshold state. The fix now properly detects and ignores these cursor reset events to preserve the gaze state.
+
+- **Added outside-window gaze detection**: Walking now also pauses/slows when gaze is detected outside the game window, matching the original intended behavior.
+
+#### Walking Behavior Changes
+
+- **Walking now slows down instead of stopping completely when looking at keyboard**: Per feedback from Kirsty (original developer), stopping completely wasn't intuitive when looking up/down hills. Walking now reduces to 15% speed when gaze is at the keyboard area or outside the window.
+
+#### Mining and Attacking Fixes
+
+- **Toggle mining now pauses when looking at keyboard**: Per EyeGazeGirl's feedback ("toggle mining meant to stop too"), continuous mining now pauses when gaze is below the hotbar or outside the window.
+
+- **Toggle attacking now pauses when looking at keyboard**: Continuous attacking now pauses when gaze is at the keyboard area or outside the window, consistent with mining behavior.
+
+#### Keybinding Persistence Fix
+
+- **Fixed keybindings resetting on every game launch**: The AutoJump module was calling `options.save()` and `options.load()` during startup config sync, which could interfere with Minecraft's keybinding loading process. The fix now only persists settings when the user manually toggles them, not during startup.

--- a/common/src/main/java/com/specialeffect/eyemine/submod/mining/ContinuouslyMine.java
+++ b/common/src/main/java/com/specialeffect/eyemine/submod/mining/ContinuouslyMine.java
@@ -37,6 +37,8 @@ import net.minecraft.world.item.Items;
 import net.minecraft.world.item.PickaxeItem;
 import org.lwjgl.glfw.GLFW;
 
+import com.specialeffect.eyemine.utils.MouseHelper;
+
 import java.util.function.BooleanSupplier;
 import java.util.function.IntSupplier;
 
@@ -94,6 +96,15 @@ public class ContinuouslyMine extends SubMod implements IConfigListener {
 		LocalPlayer player = Minecraft.getInstance().player;
 		if (player != null) {
 			final KeyMapping attackBinding = Minecraft.getInstance().options.keyAttack;
+
+			// Pause mining when gaze is at keyboard area or outside window
+			// Per EyeGazeGirl: "toggle mining meant to stop too"
+			boolean gazeAtKeyboard = MouseHelper.isGazeBelowHotbar || MouseHelper.isGazeOutsideWindow;
+			if (mIsAttacking && gazeAtKeyboard) {
+				// Release the attack key while gaze is at keyboard
+				KeyMapping.set(((KeyMappingAccessor) attackBinding).getActualKey(), false);
+				return;
+			}
 
 			if (mIsAttacking) {
 				if (player.isCreative()) {

--- a/common/src/main/java/com/specialeffect/eyemine/submod/misc/ContinuouslyAttack.java
+++ b/common/src/main/java/com/specialeffect/eyemine/submod/misc/ContinuouslyAttack.java
@@ -21,6 +21,7 @@ import com.specialeffect.eyemine.platform.EyeMineConfig;
 import com.specialeffect.eyemine.submod.IConfigListener;
 import com.specialeffect.eyemine.submod.SubMod;
 import com.specialeffect.eyemine.submod.mining.ContinuouslyMine;
+import com.specialeffect.eyemine.utils.MouseHelper;
 import com.specialeffect.utils.ModUtils;
 import dev.architectury.event.EventResult;
 import dev.architectury.event.events.client.ClientRawInputEvent;
@@ -78,6 +79,13 @@ public class ContinuouslyAttack extends SubMod implements IConfigListener {
 	public void onClientTick(Minecraft minecraft) {
 		LocalPlayer player = minecraft.player;
 		if (player != null) {
+			// Pause attacking when gaze is at keyboard area or outside window
+			// Per EyeGazeGirl: "toggle mining meant to stop too" (applies to attack as well)
+			boolean gazeAtKeyboard = MouseHelper.isGazeBelowHotbar || MouseHelper.isGazeOutsideWindow;
+			if (mIsAttacking && gazeAtKeyboard) {
+				return; // Skip attacking while gaze is at keyboard
+			}
+
 			if (mIsAttacking) {
 				if (player.isCreative() &&
 						mAutoSelectSword) {

--- a/common/src/main/java/com/specialeffect/eyemine/submod/movement/AutoJump.java
+++ b/common/src/main/java/com/specialeffect/eyemine/submod/movement/AutoJump.java
@@ -53,12 +53,17 @@ public class AutoJump extends SubMod implements IConfigListener {
 		ClientRawInputEvent.KEY_PRESSED.register(this::onKeyInput);
 	}
 
-	private void updateSettings(boolean autoJump) {
+	private void updateSettings(boolean autoJump, boolean persist) {
 		Options options = Minecraft.getInstance().options;
 		if (options != null) {
 			options.autoJump().set(autoJump);
-			options.save();
-			options.load();
+			// Only save/reload when user toggles the setting, not during startup
+			// Calling options.save()/load() during mod initialization can interfere
+			// with keybinding persistence
+			if (persist) {
+				options.save();
+				options.load();
+			}
 		}
 	}
 
@@ -66,7 +71,8 @@ public class AutoJump extends SubMod implements IConfigListener {
 	public void syncConfig() {
 		this.mAutoJumpDisabled = EyeMineConfig.getDisableAutoJumpFixes();
 		this.mDoingAutoJump = EyeMineConfig.getDefaultDoAutoJump();
-		this.updateSettings(mDoingAutoJump);
+		// Don't persist during config sync (startup) - this can reset keybindings
+		this.updateSettings(mDoingAutoJump, false);
 		StateOverlay.setStateLeftIcon(mIconIndex, mDoingAutoJump);
 	}
 
@@ -101,7 +107,8 @@ public class AutoJump extends SubMod implements IConfigListener {
 
 		if (!mAutoJumpDisabled && autoJumpKeyBinding.matches(keyCode, scanCode) && autoJumpKeyBinding.consumeClick()) {
 			mDoingAutoJump = !mDoingAutoJump;
-			this.updateSettings(mDoingAutoJump);
+			// User toggled the setting, so persist it
+			this.updateSettings(mDoingAutoJump, true);
 			StateOverlay.setStateLeftIcon(mIconIndex, mDoingAutoJump);
 			ModUtils.sendPlayerMessage("Auto jump: " + (mDoingAutoJump ? "ON" : "OFF"));
 		}

--- a/common/src/main/java/com/specialeffect/eyemine/submod/movement/MoveWithGaze.java
+++ b/common/src/main/java/com/specialeffect/eyemine/submod/movement/MoveWithGaze.java
@@ -132,15 +132,15 @@ public class MoveWithGaze extends SubMod implements IConfigListener {
 			//   hasn't moved at all. This is mainly applicable to gaze input.
 			// - If walking into a wall, don't keep walking fast!
 
-			// Slow down walking when gaze is below the hotbar (where EyeMine keyboard renders)
-			// or when gaze is outside the window entirely (original behavior per dev)
-			// Per Kirsty: stopping completely isn't intuitive (e.g., looking up/down hills),
-			// so we slow down significantly instead
+			// Stop walking when gaze is below the hotbar (where EyeMine keyboard renders)
+			// or when gaze is outside the window entirely
+			// Kirsty's "stopping completely isn't intuitive" feedback was about pitch-based
+			// slowdown on hills (in-game looking direction), NOT about the on-screen keyboard
 			// This check must be OUTSIDE the hasPendingEvent() condition because gaze at
 			// keyboard area may be in the deadzone where no pending event is registered
 			boolean gazeAtKeyboard = MouseHelper.isGazeBelowHotbar || MouseHelper.isGazeOutsideWindow;
 			if (gazeAtKeyboard && !mWasPausedByGaze) {
-				LOGGER.info("Walking slowed - gaze {}",
+				LOGGER.info("Walking stopped - gaze {}",
 					MouseHelper.isGazeOutsideWindow ? "outside window" : "below hotbar threshold");
 				mWasPausedByGaze = true;
 			} else if (!gazeAtKeyboard && mWasPausedByGaze) {
@@ -150,10 +150,12 @@ public class MoveWithGaze extends SubMod implements IConfigListener {
 			if (mDoingAutoWalk && null == minecraft.screen && (mMoveWhenMouseStationary || MouseHandlerMod.hasPendingEvent())) {
 				double forward = (double) mCustomSpeedFactor;
 
-				// Slow down significantly when gaze is at keyboard area or outside window
-				// Per Kirsty: stopping completely isn't intuitive when looking up/down hills
+				// Fully stop when gaze is at keyboard area or outside window
+				// Per Kirsty: the "stopping completely isn't intuitive" feedback was about
+				// pitch-based slowdown on hills (handled by slowdownFactorPitch below),
+				// NOT about looking at the on-screen keyboard — that should always stop
 				if (gazeAtKeyboard) {
-					forward *= 0.15; // 15% speed when looking at keyboard
+					forward = 0.0;
 				}
 
 				// Slow down when you're looking really far up/down, or turning round quickly
@@ -289,9 +291,10 @@ public class MoveWithGaze extends SubMod implements IConfigListener {
 
 	private double slowdownFactorPitch(Player player) {
 		float f = player.getXRot();
-		// Fully stop when looking at extreme angles (e.g., onboard keyboard)
+		// Slow to a crawl at extreme angles but never fully stop
+		// (fully stopping when looking up/down feels unintuitive per user feedback)
 		if (f < -80 || f > 80) {
-			return 0.0f;
+			return 0.05f;
 		} else if (f < -75 || f > 75) {
 			return 0.15f;
 		} else if (f < -60 || f > 60) {

--- a/common/src/main/java/com/specialeffect/eyemine/submod/movement/MoveWithGaze.java
+++ b/common/src/main/java/com/specialeffect/eyemine/submod/movement/MoveWithGaze.java
@@ -132,25 +132,29 @@ public class MoveWithGaze extends SubMod implements IConfigListener {
 			//   hasn't moved at all. This is mainly applicable to gaze input.
 			// - If walking into a wall, don't keep walking fast!
 
-			// Pause walking when gaze is below the hotbar (where EyeMine keyboard renders)
+			// Slow down walking when gaze is below the hotbar (where EyeMine keyboard renders)
 			// or when gaze is outside the window entirely (original behavior per dev)
+			// Per Kirsty: stopping completely isn't intuitive (e.g., looking up/down hills),
+			// so we slow down significantly instead
 			// This check must be OUTSIDE the hasPendingEvent() condition because gaze at
 			// keyboard area may be in the deadzone where no pending event is registered
-			if (mDoingAutoWalk && null == minecraft.screen &&
-					(MouseHelper.isGazeBelowHotbar || MouseHelper.isGazeOutsideWindow)) {
-				if (!mWasPausedByGaze) {
-					LOGGER.info("Walking paused - gaze {} threshold",
-						MouseHelper.isGazeOutsideWindow ? "outside window" : "below hotbar");
-					mWasPausedByGaze = true;
-				}
-				KeyboardInputHelper.setWalkOverride(false, 0.0f);
-				return;
-			} else {
+			boolean gazeAtKeyboard = MouseHelper.isGazeBelowHotbar || MouseHelper.isGazeOutsideWindow;
+			if (gazeAtKeyboard && !mWasPausedByGaze) {
+				LOGGER.info("Walking slowed - gaze {}",
+					MouseHelper.isGazeOutsideWindow ? "outside window" : "below hotbar threshold");
+				mWasPausedByGaze = true;
+			} else if (!gazeAtKeyboard && mWasPausedByGaze) {
 				mWasPausedByGaze = false;
 			}
 
 			if (mDoingAutoWalk && null == minecraft.screen && (mMoveWhenMouseStationary || MouseHandlerMod.hasPendingEvent())) {
 				double forward = (double) mCustomSpeedFactor;
+
+				// Slow down significantly when gaze is at keyboard area or outside window
+				// Per Kirsty: stopping completely isn't intuitive when looking up/down hills
+				if (gazeAtKeyboard) {
+					forward *= 0.15; // 15% speed when looking at keyboard
+				}
 
 				// Slow down when you're looking really far up/down, or turning round quickly
 				if (EyeMineConfig.getSlowdownOnCorners()) {

--- a/common/src/main/java/com/specialeffect/eyemine/submod/movement/MoveWithGaze2.java
+++ b/common/src/main/java/com/specialeffect/eyemine/submod/movement/MoveWithGaze2.java
@@ -92,15 +92,12 @@ public class MoveWithGaze2 extends SubMod implements IConfigListener {
 	public void onClientTick(Minecraft minecraft) {
 		LocalPlayer player = Minecraft.getInstance().player;
 		if (player != null) {
-			// Pause walking when gaze is below the hotbar (where EyeMine keyboard renders)
+			// Slow down walking when gaze is below the hotbar (where EyeMine keyboard renders)
 			// or when gaze is outside the window entirely (original behavior per dev)
+			// Per Kirsty: stopping completely isn't intuitive when looking up/down hills
 			// This check must be OUTSIDE the hasPendingEvent() condition because gaze at
 			// keyboard area may be in the deadzone where no pending event is registered
-			if (mDoingAutoWalk && minecraft.screen == null &&
-					(MouseHelper.isGazeBelowHotbar || MouseHelper.isGazeOutsideWindow)) {
-				KeyboardInputHelper.setWalkOverride(false, 0.0f);
-				return;
-			}
+			boolean gazeAtKeyboard = MouseHelper.isGazeBelowHotbar || MouseHelper.isGazeOutsideWindow;
 
 			if (mDoingAutoWalk && minecraft.screen == null && // no gui visible
 					(mMoveWhenMouseStationary || MouseHandlerMod.hasPendingEvent())) {
@@ -132,9 +129,15 @@ public class MoveWithGaze2 extends SubMod implements IConfigListener {
 					}
 				}
 
-				// scaled by mCustomSpeedFactor 
+				// scaled by mCustomSpeedFactor
 				walkForwardAmount *= (float) 0.15F;
 				walkForwardAmount *= mCustomSpeedFactor;
+
+				// Slow down significantly when gaze is at keyboard area
+				if (gazeAtKeyboard) {
+					walkForwardAmount *= 0.15f; // 15% speed when looking at keyboard
+				}
+
 				KeyboardInputHelper.setWalkOverride(true, walkForwardAmount);
 			}
 		}

--- a/common/src/main/java/com/specialeffect/eyemine/submod/utils/DwellAction.java
+++ b/common/src/main/java/com/specialeffect/eyemine/submod/utils/DwellAction.java
@@ -20,6 +20,7 @@ import com.specialeffect.eyemine.platform.EyeMineConfig;
 import com.specialeffect.eyemine.submod.IConfigListener;
 import com.specialeffect.eyemine.submod.SubMod;
 import com.specialeffect.eyemine.submod.mouse.MouseHandlerMod;
+import com.specialeffect.eyemine.utils.MouseHelper;
 import com.specialeffect.utils.ModUtils;
 import dev.architectury.event.EventResult;
 import dev.architectury.event.events.client.ClientGuiEvent;
@@ -109,7 +110,9 @@ public abstract class DwellAction extends SubMod implements IConfigListener {
 			lastTime = time;
 
 			if (mDwelling && !ModUtils.hasActiveGui()) {
-				if (MouseHandlerMod.hasPendingEvent() || moveWhenMouseStationary) {
+				// Stop dwell actions when gaze is at keyboard area or outside window
+				boolean gazeAtKeyboard = MouseHelper.isGazeBelowHotbar || MouseHelper.isGazeOutsideWindow;
+				if (!gazeAtKeyboard && (MouseHandlerMod.hasPendingEvent() || moveWhenMouseStationary)) {
 					// What are we currently targeting?
 					BlockHitResult rayTraceBlock = ModUtils.getMouseOverBlock();
 					TargetBlock currentTarget = (rayTraceBlock == null) ? null : new TargetBlock(rayTraceBlock);

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ minecraft_version=1.21.1
 enabled_platforms=fabric,neoforge
 
 archives_base_name=eyemine
-mod_version=6.0.1
+mod_version=6.0.2-SNAPSHOT
 maven_group=com.specialeffect
 
 architectury_version=13.0.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ minecraft_version=1.21.1
 enabled_platforms=fabric,neoforge
 
 archives_base_name=eyemine
-mod_version=6.0.2-SNAPSHOT
+mod_version=6.0.2
 maven_group=com.specialeffect
 
 architectury_version=13.0.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ minecraft_version=1.21.1
 enabled_platforms=fabric,neoforge
 
 archives_base_name=eyemine
-mod_version=6.0.0
+mod_version=6.0.1
 maven_group=com.specialeffect
 
 architectury_version=13.0.8

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,8 +2,9 @@ pluginManagement {
     repositories {
         maven { url "https://maven.fabricmc.net/" }
         maven { url "https://maven.architectury.dev/" }
-        maven { url "https://maven.neoforged.net/" }
+        maven { url "https://maven.neoforged.net/releases/" }
         maven { url "https://maven.minecraftforge.net/" }
+        mavenCentral()
         gradlePluginPortal()
     }
 }


### PR DESCRIPTION
## Version 6.0.2

### Bug Fixes

#### Gaze-Based Walking Refinements

- **Walking now fully stops when gaze is at the on-screen keyboard or outside the window**: In 6.0.1, walking was reduced to 15% speed in these cases. After further testing, full stop is the correct behavior. 

- **Extreme pitch angles no longer fully stop walking**: Looking straight up or down (beyond 80°) now slows movement to 5% instead of stopping entirely. This preserves the ability to navigate hills and look around without losing all momentum.

#### Dwell Action Improvements

- **Dwell actions now suppressed when gaze is at keyboard area or outside window**: Prevents unintended dwell-triggered interactions (ie block placement, item use) while the user is interacting with the on-screen keyboard.